### PR TITLE
Add formatter and linter

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,5 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Format Check
+      run: cargo fmt --check
+    - name: Linter Check
+      run: cargo clippy --no-deps -Dwarnings
     - name: Build
       run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,12 +13,13 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    env:
+      RUSTFLAGS: "-Dwarnings"
     steps:
     - uses: actions/checkout@v3
     - name: Format Check
       run: cargo fmt --check
     - name: Linter Check
-      run: cargo clippy --no-deps -Dwarnings
+      run: cargo clippy --no-deps
     - name: Build
       run: cargo build --verbose

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -19,7 +19,7 @@ fn check_content_type(response: &Response) -> (bool, Option<String>) {
         let content_type = response.headers().get("Content-Type").unwrap().to_str();
         if content_type.is_ok() {
             let mut content_type = content_type.unwrap().to_string().to_lowercase();
-            let split_index = content_type.find(";");
+            let split_index = content_type.find(';');
 
             if split_index.is_some() {
                 let (split_content_type, _) = content_type.split_at(split_index.unwrap());
@@ -85,7 +85,7 @@ pub async fn visit_page(
             .send()
             .await;
         let response: Response;
-        let is_good = !response_result.is_err();
+        let is_good = response_result.is_ok();
 
         {
             // Acquire a lock on the graph so that we can update it with our findings for this page
@@ -250,5 +250,5 @@ pub async fn visit_root_page(
         page_map.lock().unwrap().insert(url.clone(), root_index);
     }
 
-    return visit_page(root_index, client, options, graph, page_map, 0).await;
+    visit_page(root_index, client, options, graph, page_map, 0).await
 }

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -17,12 +17,12 @@ use crate::{Link, Page, PageGraph, PageMap, SpiderOptions};
 fn check_content_type(response: &Response) -> (bool, Option<String>) {
     if response.headers().contains_key("Content-Type") {
         let content_type = response.headers().get("Content-Type").unwrap().to_str();
-        if content_type.is_ok() {
-            let mut content_type = content_type.unwrap().to_string().to_lowercase();
-            let split_index = content_type.find(';');
+        if let Ok(content_type) = content_type {
+            let mut content_type = content_type.to_string().to_lowercase();
+            let split_index: Option<usize> = content_type.find(';');
 
-            if split_index.is_some() {
-                let (split_content_type, _) = content_type.split_at(split_index.unwrap());
+            if let Some(split_index) = split_index {
+                let (split_content_type, _) = content_type.split_at(split_index);
                 content_type = split_content_type.to_string();
             }
 

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -1,14 +1,14 @@
 //! Holds algorithm(s) used to traverse across a website
 
 use async_recursion::async_recursion;
-use scraper::{Html, Element};
-use reqwest::{Client, Response};
-use url::Url;
 use petgraph::graph::NodeIndex;
+use reqwest::{Client, Response};
+use scraper::{Element, Html};
 use std::sync::Mutex;
+use url::Url;
 
-use crate::{PageGraph, PageMap, Link, Page, SpiderOptions};
-use crate::url_helpers::{get_url_from_element, check_domain};
+use crate::url_helpers::{check_domain, get_url_from_element};
+use crate::{Link, Page, PageGraph, PageMap, SpiderOptions};
 
 /// Attempts to retrieve the HTTP ContentType from a Response and check if it is some form of HTML document.
 /// Returns `(true, Some(content_type: String))` if the ContentType is some form of HTML document.
@@ -20,15 +20,15 @@ fn check_content_type(response: &Response) -> (bool, Option<String>) {
         if content_type.is_ok() {
             let mut content_type = content_type.unwrap().to_string().to_lowercase();
             let split_index = content_type.find(";");
-            
+
             if split_index.is_some() {
                 let (split_content_type, _) = content_type.split_at(split_index.unwrap());
                 content_type = split_content_type.to_string();
             }
 
             match content_type.as_str() {
-                "text/html" | "html" => { return (true, Some(content_type)) },
-                _ => { return (false, Some(content_type)) }
+                "text/html" | "html" => return (true, Some(content_type)),
+                _ => return (false, Some(content_type)),
             }
         }
     }
@@ -51,23 +51,39 @@ fn check_content_type(response: &Response) -> (bool, Option<String>) {
 /// * HTTP GET request to the URL results in a non-2XX HTTP status code
 /// * Newly discovered URL has already been visited
 #[async_recursion]
-pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderOptions, graph_mutex: &Mutex<&mut PageGraph>, page_map_mutex: &Mutex<&mut PageMap>, current_depth: i32) -> bool {
+pub async fn visit_page(
+    node_index: NodeIndex,
+    client: &Client,
+    options: &SpiderOptions,
+    graph_mutex: &Mutex<&mut PageGraph>,
+    page_map_mutex: &Mutex<&mut PageMap>,
+    current_depth: i32,
+) -> bool {
     let url: Url;
     let mut new_nodes = Vec::<NodeIndex>::new();
     let mut found_problem: bool = false;
-    // Reserve some space for our new node indices. 
+    // Reserve some space for our new node indices.
     new_nodes.reserve(64);
 
     {
         // Momentarily acquire the lock so that we can grab the URL of the page
-        url = graph_mutex.lock().unwrap().node_weight(node_index).unwrap().url.clone();
-    }   // End of scope, releases the lock
+        url = graph_mutex
+            .lock()
+            .unwrap()
+            .node_weight(node_index)
+            .unwrap()
+            .url
+            .clone();
+    } // End of scope, releases the lock
 
     {
         // Start of new scope, this is to get the document, parse links, and update the graph
 
         // Send an HTTP(S) GET request for the desired URL
-        let response_result = client.request(reqwest::Method::GET, url.clone()).send().await;
+        let response_result = client
+            .request(reqwest::Method::GET, url.clone())
+            .send()
+            .await;
         let response: Response;
         let is_good = !response_result.is_err();
 
@@ -92,8 +108,11 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
 
             // If Content-Type is not HTML, then don't try to parse the HTML
             if !parse_html {
-                if options.verbose { 
-                    println!("Not parsing HTML for: {}, Content-Type is {:?}", url, content_type);
+                if options.verbose {
+                    println!(
+                        "Not parsing HTML for: {}, Content-Type is {:?}",
+                        url, content_type
+                    );
                 }
                 return true;
             }
@@ -102,7 +121,7 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
             let parse_html = check_domain(&options.domain_name, &url);
 
             if !parse_html {
-                if options.verbose { 
+                if options.verbose {
                     println!("Not parsing HTML for: {}, outside of domain", url);
                 }
                 return true;
@@ -111,7 +130,7 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
 
         // Get the Contents of the page
         let contents = response.text().await;
-        
+
         // Acquire a lock on the graph so that we can update it with our findings for this page
         let mut graph = graph_mutex.lock().unwrap();
         let page = graph.node_weight_mut(node_index).unwrap();
@@ -130,16 +149,15 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
         if options.verbose {
             println!("Visited page {}", url.as_str());
         }
-        
+
         let links = html.select(options.link_selector.as_ref());
 
         let mut page_map = page_map_mutex.lock().unwrap();
 
         for l in links {
-
             if l.has_class(&options.skip_class, scraper::CaseSensitivity::CaseSensitive) {
                 // Link is marked with the spider-crab-skip class, so skip it
-                continue
+                continue;
             }
 
             // Parse out a URL from the link
@@ -155,30 +173,21 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
             let existing_page = page_map.get(&next_url);
             if existing_page.is_some() {
                 // Target URL has already been visited
-                graph.add_edge(node_index, 
-                    *existing_page.unwrap(), 
-                    Link { html: l.html() }
-                    );
+                graph.add_edge(node_index, *existing_page.unwrap(), Link { html: l.html() });
                 continue;
             }
-            
+
             // Target URL has not been visited yet, add a node to the graph
-            let new_node = graph.add_node(
-                    Page {
-                    url: next_url.clone(),
-                    title: None,
-                    content_type: None,
-                    good: false,
-                    checked: false
-                }
-            );
+            let new_node = graph.add_node(Page {
+                url: next_url.clone(),
+                title: None,
+                content_type: None,
+                good: false,
+                checked: false,
+            });
 
             // Add an edge to the graph connecting current page to the target page
-            graph.add_edge(node_index, new_node, 
-                Link { 
-                    html: l.html()
-                }
-            );
+            graph.add_edge(node_index, new_node, Link { html: l.html() });
 
             // Add an entry to the page HashMap to mark that we're going to visit the page
             page_map.insert(next_url.clone(), new_node);
@@ -193,13 +202,20 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
             new_nodes.push(new_node);
         }
     }
-    
+
     let mut futures_vec = Vec::new();
     futures_vec.reserve_exact(new_nodes.len());
 
     // Create a future for each node we discovered
     for node in new_nodes {
-        futures_vec.push(visit_page(node, client, options, graph_mutex, page_map_mutex, current_depth + 1));
+        futures_vec.push(visit_page(
+            node,
+            client,
+            options,
+            graph_mutex,
+            page_map_mutex,
+            current_depth + 1,
+        ));
     }
 
     // Wait for all the tasks to complete
@@ -211,21 +227,25 @@ pub async fn visit_page(node_index: NodeIndex, client:&Client, options: &SpiderO
 
 /// Visits the page pointed to by the `url` and then recursively calls `visit_page()` on all links contained in that page.
 /// Entry point to the page traversal algorithm.
-pub async fn visit_root_page(url: &Url, client: &Client, options: &SpiderOptions, graph: &Mutex<&mut PageGraph>, page_map: &Mutex<&mut PageMap>)
-    -> bool {
-
+pub async fn visit_root_page(
+    url: &Url,
+    client: &Client,
+    options: &SpiderOptions,
+    graph: &Mutex<&mut PageGraph>,
+    page_map: &Mutex<&mut PageMap>,
+) -> bool {
     let root_index: NodeIndex;
-    { 
+    {
         // Insert the root page as a node into the graph
         root_index = graph.lock().unwrap().add_node(Page {
             title: None,
             content_type: None,
             good: false,
             checked: false,
-            url: url.clone()
+            url: url.clone(),
         });
 
-        // Mark the root node as visited because visit_page assumes 
+        // Mark the root node as visited because visit_page assumes
         //  that the target page is already marked as visited
         page_map.lock().unwrap().insert(url.clone(), root_index);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,10 @@
 #[derive(Debug)]
 /// Custom error type for Spider Crab
 pub struct SpiderError {
-    pub message: String
+    pub message: String,
 }
 
-impl std::error::Error for SpiderError { }
+impl std::error::Error for SpiderError {}
 
 impl std::fmt::Display for SpiderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-use scraper::{Selector, selector::CssLocalName};
-use url::Url;
 use petgraph::graph::{DiGraph, NodeIndex};
+use scraper::{selector::CssLocalName, Selector};
 use std::collections::HashMap;
+use url::Url;
 
-pub mod error;
 pub mod algo;
+pub mod error;
 pub mod url_helpers;
 
 pub struct Link {
-    pub html: String
+    pub html: String,
 }
 
 /// Representation of a document/page
@@ -21,8 +21,8 @@ pub struct Page {
     pub good: bool,
     /// True if this page was visited, false otherwise
     pub checked: bool,
-    /// URL that this page is represented by. Does not include URL parameters or fragments 
-    pub url: Url
+    /// URL that this page is represented by. Does not include URL parameters or fragments
+    pub url: Url,
 }
 
 /// Helper type for the HashMap that maps Urls to Nodes in the graph
@@ -30,7 +30,6 @@ pub type PageMap = HashMap<Url, NodeIndex>;
 
 /// Helper type that tracks all visited pages and the links between them
 pub type PageGraph = DiGraph<Page, Link>;
-
 
 /// Options to pass to the traversal algorithm
 pub struct SpiderOptions {
@@ -50,7 +49,7 @@ pub struct SpiderOptions {
     /// Flag to enable verbose mode. True if verbose mode enabled.
     pub verbose: bool,
     /// Name of the CSS class that marks elements to not check URLs for
-    pub skip_class: CssLocalName
+    pub skip_class: CssLocalName,
 }
 
 impl SpiderOptions {
@@ -62,7 +61,7 @@ impl SpiderOptions {
             domain_name: domain_name.to_string(),
             quiet: false,
             verbose: false,
-            skip_class: CssLocalName::from("scrab-skip")
+            skip_class: CssLocalName::from("scrab-skip"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,44 +1,55 @@
 use clap::{Arg, ArgAction, Command};
+use std::sync::Mutex;
 use url::Url;
-use std::{sync::Mutex};
 
-use spider_crab::{SpiderOptions, PageGraph, PageMap};
+use spider_crab::algo::visit_root_page;
 use spider_crab::error::SpiderError;
-use spider_crab::algo::{visit_root_page};
+use spider_crab::{PageGraph, PageMap, SpiderOptions};
 
-#[tokio::main(flavor="current_thread")]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let matches = Command::new("Spider Crab")
         .version("0.0.1")
         .about("Checks links and images in a webpage.")
         .author("Tyler Sengia")
-        .arg(Arg::new("url")
-            .action(ArgAction::Set)
-            .required(true)
-            .help("URL of the webpage to check."))
-        .arg(Arg::new("depth")
-            .short('d')
-            .long("depth")
-            .action(ArgAction::Set)
-            .default_value("-1")
-            .value_parser(clap::value_parser!(i32))
-            .help("Depth of links to check. Default is -1 which is unlimited."))
-        .arg(Arg::new("quiet")
-            .short('q')
-            .long("quiet")
-            .action(ArgAction::SetTrue)
-            .help("Do not print to STDOUT or STDERR."))
-        .arg(Arg::new("verbose")
-            .short('v')
-            .long("verbose")
-            .action(ArgAction::SetTrue)
-            .help("Print more log messages."))
+        .arg(
+            Arg::new("url")
+                .action(ArgAction::Set)
+                .required(true)
+                .help("URL of the webpage to check."),
+        )
+        .arg(
+            Arg::new("depth")
+                .short('d')
+                .long("depth")
+                .action(ArgAction::Set)
+                .default_value("-1")
+                .value_parser(clap::value_parser!(i32))
+                .help("Depth of links to check. Default is -1 which is unlimited."),
+        )
+        .arg(
+            Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .action(ArgAction::SetTrue)
+                .help("Do not print to STDOUT or STDERR."),
+        )
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(ArgAction::SetTrue)
+                .help("Print more log messages."),
+        )
         .get_matches();
 
-    let url_str = matches.get_one::<String>("url").expect("No URL supplied!").as_str();
+    let url_str = matches
+        .get_one::<String>("url")
+        .expect("No URL supplied!")
+        .as_str();
 
     let url = Url::parse(url_str).unwrap();
-    
+
     let depth: i32 = *matches.get_one::<i32>("depth").expect("Invalid depth!");
 
     let quiet: bool = matches.get_flag("quiet");
@@ -70,17 +81,18 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         println!("Discovered {} links", graph.edge_count());
     }
 
-    if result  {
+    if result {
         if !quiet {
             println!("All links good!");
         }
         return Ok(());
-    }
-    else {
+    } else {
         if !quiet {
             println!("Something failed!");
         }
-        let e = Box::new(SpiderError { message: String::from("Check failed!") }) as Box<dyn std::error::Error>;
+        let e = Box::new(SpiderError {
+            message: String::from("Check failed!"),
+        }) as Box<dyn std::error::Error>;
         return Err(e);
     }
 }

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -1,7 +1,7 @@
 //! Helper functions called by the page traversal algorithm
 
-use url::{Url, ParseError};
 use scraper::ElementRef;
+use url::{ParseError, Url};
 
 /// Attempt to extract and parse a URL from a `<a>` HTML element
 /// Returns `Some(Url)` if extract + parse was successful
@@ -11,25 +11,24 @@ pub fn get_url_from_element(element: ElementRef, current_url: &Url) -> Option<Ur
 
     if href_attribute.is_none() {
         // Element is missing href attribute
-        return None
+        return None;
     }
 
     let next_url_str = href_attribute.unwrap();
 
     if next_url_str.len() == 0 {
         // href attribute value is ""
-        return None
+        return None;
     }
 
     let next_url = parse_relative_or_absolute_url(current_url, next_url_str);
     if next_url.is_none() {
         // Failed to parse URL in the href
-        return None
+        return None;
     }
 
     next_url
 }
-
 
 /// Attempts to grab the domain name from `url` and compare it against `domain_name`.
 /// Returns `true` if domain names match.
@@ -45,7 +44,6 @@ pub fn check_domain(domain_name: &str, url: &Url) -> bool {
     // Return true if the two domains match
     domain_name == url_domain
 }
-
 
 /// Parses a string into a URL. String can be an absolute URL, or a relative URL.
 /// If `url_str` is a relative URL, then it will be parsed relative to `current_url`
@@ -64,15 +62,15 @@ pub fn parse_relative_or_absolute_url(current_url: &Url, url_str: &str) -> Optio
                 parsed_url = current_url.join(url_str);
                 if parsed_url.is_err() {
                     // Relative URL parse failed
-                    return None
+                    return None;
                 }
             }
             // URL parse failed entirely, not a valid URL
-            _ => return None
+            _ => return None,
         }
     }
-    
-    // Remove anything with a # in the parsed URL to deduplicate 
+
+    // Remove anything with a # in the parsed URL to deduplicate
     //  URLs pointing to same page but different sections
     let mut parsed_url = parsed_url.unwrap();
     parsed_url.set_fragment(None);

--- a/src/url_helpers.rs
+++ b/src/url_helpers.rs
@@ -9,23 +9,17 @@ use url::{ParseError, Url};
 pub fn get_url_from_element(element: ElementRef, current_url: &Url) -> Option<Url> {
     let href_attribute = element.attr("href");
 
-    if href_attribute.is_none() {
-        // Element is missing href attribute
-        return None;
-    }
+    href_attribute?;
 
     let next_url_str = href_attribute.unwrap();
 
-    if next_url_str.len() == 0 {
+    if next_url_str.is_empty() {
         // href attribute value is ""
         return None;
     }
 
     let next_url = parse_relative_or_absolute_url(current_url, next_url_str);
-    if next_url.is_none() {
-        // Failed to parse URL in the href
-        return None;
-    }
+    next_url.as_ref()?;
 
     next_url
 }
@@ -75,5 +69,5 @@ pub fn parse_relative_or_absolute_url(current_url: &Url, url_str: &str) -> Optio
     let mut parsed_url = parsed_url.unwrap();
     parsed_url.set_fragment(None);
 
-    return Some(parsed_url);
+    Some(parsed_url)
 }


### PR DESCRIPTION
This PR performs the following changes:
- Adds `cargo fmt --check` to the CI build plan
- Adds `cargo clippy -Dwarnings` to the CI build plan
- Formatted code according to `cargo fmt`
- Fixed all clippy lint errors/warnings

From now on, all code must be formatted with `cargo fmt` and clippy lints resolved in order to pass the CI build process.