### PR TITLE
Add dot output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Ignore generated .dot files
+*.dot

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -78,11 +78,13 @@ pub async fn visit_page(
             let mut graph = graph_mutex.lock().unwrap();
             let page = graph.node_weight_mut(node_index).unwrap();
 
+            page.checked = true;
             if response_result.is_err() {
                 if options.verbose {
                     println!("Found bad link! {}", url);
                 }
                 page.status_code = response_result.err().unwrap().status();
+                page.good = Some(false);
                 return false;
             }
 
@@ -137,6 +139,12 @@ pub async fn visit_page(
         {
             let page = graph.node_weight_mut(node_index).unwrap();
             page.good = Some(true);
+
+            let title_element = html.select(options.title_selector.as_ref());
+            let title_element = title_element.last();
+            if title_element.is_some() {
+                page.title = Some(title_element.unwrap().inner_html())
+            }
         }
 
         if options.verbose {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -3,14 +3,14 @@ use crate::{Link, Page, PageGraph, SpiderCrab};
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::NodeIndex;
 
-fn get_link_dot_attributes<'a>(
-    graph: &'a PageGraph,
-    edge_ref: petgraph::graph::EdgeReference<'_, Link>,
+fn get_link_dot_attributes(
+    _graph: &PageGraph,
+    _edge_ref: petgraph::graph::EdgeReference<'_, Link>,
 ) -> String {
     "".to_string()
 }
 
-fn get_page_dot_attributes<'a>(graph: &'a PageGraph, (index, page): (NodeIndex, &Page)) -> String {
+fn get_page_dot_attributes(_graph: &PageGraph, (_index, page): (NodeIndex, &Page)) -> String {
     let title: String = match (page.checked, page.title.clone()) {
         (false, _) => "???".to_string(),
         (true, None) => "NO TITLE".to_string(),
@@ -23,12 +23,12 @@ fn get_page_dot_attributes<'a>(graph: &'a PageGraph, (index, page): (NodeIndex, 
         (true, None) => "orange",
     };
 
-    return format!(
+    format!(
         "label=\"{}\n{}\", color={}",
         title,
         page.url.as_str(),
         color
-    );
+    )
 }
 
 impl SpiderCrab {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,0 +1,32 @@
+//! Holds functions to render the Page Graph as a Dot graphiz format
+use petgraph::dot::{Dot, Config};
+use petgraph::graph::NodeIndex;
+use crate::{Link, Page, PageGraph, SpiderCrab};
+
+
+fn get_link_dot_attributes<'a>(graph: &'a PageGraph, edge_ref: petgraph::graph::EdgeReference<'_, Link>) -> String {
+    "".to_string()
+}
+
+fn get_page_dot_attributes<'a>(graph: &'a PageGraph, (index, page): (NodeIndex, &Page)) -> String {
+    let title: String = match (page.checked, page.title.clone()) {
+        (false, _) => "???".to_string(),
+        (true, None) => "NO TITLE".to_string(),
+        (true, Some(t)) => t.trim().to_string()
+    };
+    let color = match (page.checked, page.good) {
+        (false, _) => "black",
+        (true, Some(true)) => "green",
+        (true, Some(false)) => "red",
+        (true, None) => "orange"
+    };
+
+    return format!("label=\"{}\n{}\", color={}", title, page.url.as_str(), color);
+}
+
+
+impl SpiderCrab {
+    pub fn get_dot_format(&self) -> String {
+        format!("{:?}", Dot::with_attr_getters(&self.graph, &[Config::EdgeNoLabel, Config::NodeNoLabel], &get_link_dot_attributes, &get_page_dot_attributes))
+    }
+}

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,10 +1,12 @@
 //! Holds functions to render the Page Graph as a Dot graphiz format
-use petgraph::dot::{Dot, Config};
-use petgraph::graph::NodeIndex;
 use crate::{Link, Page, PageGraph, SpiderCrab};
+use petgraph::dot::{Config, Dot};
+use petgraph::graph::NodeIndex;
 
-
-fn get_link_dot_attributes<'a>(graph: &'a PageGraph, edge_ref: petgraph::graph::EdgeReference<'_, Link>) -> String {
+fn get_link_dot_attributes<'a>(
+    graph: &'a PageGraph,
+    edge_ref: petgraph::graph::EdgeReference<'_, Link>,
+) -> String {
     "".to_string()
 }
 
@@ -12,21 +14,33 @@ fn get_page_dot_attributes<'a>(graph: &'a PageGraph, (index, page): (NodeIndex, 
     let title: String = match (page.checked, page.title.clone()) {
         (false, _) => "???".to_string(),
         (true, None) => "NO TITLE".to_string(),
-        (true, Some(t)) => t.trim().to_string()
+        (true, Some(t)) => t.trim().to_string(),
     };
     let color = match (page.checked, page.good) {
         (false, _) => "black",
         (true, Some(true)) => "green",
         (true, Some(false)) => "red",
-        (true, None) => "orange"
+        (true, None) => "orange",
     };
 
-    return format!("label=\"{}\n{}\", color={}", title, page.url.as_str(), color);
+    return format!(
+        "label=\"{}\n{}\", color={}",
+        title,
+        page.url.as_str(),
+        color
+    );
 }
-
 
 impl SpiderCrab {
     pub fn get_dot_format(&self) -> String {
-        format!("{:?}", Dot::with_attr_getters(&self.graph, &[Config::EdgeNoLabel, Config::NodeNoLabel], &get_link_dot_attributes, &get_page_dot_attributes))
+        format!(
+            "{:?}",
+            Dot::with_attr_getters(
+                &self.graph,
+                &[Config::EdgeNoLabel, Config::NodeNoLabel],
+                &get_link_dot_attributes,
+                &get_page_dot_attributes
+            )
+        )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,19 @@ use url::{Host, Url};
 
 pub mod algo;
 pub mod error;
+pub mod dot;
 pub mod url_helpers;
 
 #[cfg(test)]
 pub mod tests;
 
+#[derive(Debug)]
 pub struct Link {
     pub html: String,
 }
 
 /// Representation of a document/page
+#[derive(Debug)]
 pub struct Page {
     /// Title of the page
     pub title: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ use std::sync::Mutex;
 use url::{Host, Url};
 
 pub mod algo;
-pub mod error;
 pub mod dot;
+pub mod error;
 pub mod url_helpers;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ use clap::{Arg, ArgAction, Command};
 use spider_crab::error::SpiderError;
 use spider_crab::SpiderCrab;
 
-
-fn save_graph_file(spider_crab: &SpiderCrab, filename: &String) -> Result<(), Box<dyn std::error::Error>> {
+fn save_graph_file(
+    spider_crab: &SpiderCrab,
+    filename: &String,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut f = File::create(filename.as_str())?;
     f.write_all(spider_crab.get_dot_format().as_bytes())?;
     Ok(())
@@ -49,10 +51,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         )
         .arg(
             Arg::new("dot")
-            .short('o')
-            .long("dot")
-            .action(ArgAction::Set)
-            .help("Save output to file in graphiz Dot format.")
+                .short('o')
+                .long("dot")
+                .action(ArgAction::Set)
+                .help("Save output to file in graphiz Dot format."),
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ use spider_crab::SpiderCrab;
 
 fn save_graph_file(
     spider_crab: &SpiderCrab,
-    filename: &String,
+    filename: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut f = File::create(filename.as_str())?;
+    let mut f = File::create(filename)?;
     f.write_all(spider_crab.get_dot_format().as_bytes())?;
     Ok(())
 }
@@ -94,7 +94,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             println!("All links good!");
         }
         if dot_output_file.is_some() {
-            save_graph_file(&spider_crab, dot_output_file.unwrap());
+            let save_result = save_graph_file(&spider_crab, dot_output_file.unwrap());
+            if save_result.is_err() {
+                return Err(save_result.err().unwrap());
+            }
         }
         return Ok(());
     } else {
@@ -113,7 +116,14 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             html: None,
         }) as Box<dyn std::error::Error>;
         if dot_output_file.is_some() {
-            save_graph_file(&spider_crab, dot_output_file.unwrap());
+            let save_result = save_graph_file(&spider_crab, dot_output_file.unwrap());
+            if save_result.is_err() {
+                eprintln!(
+                    "Save to Dot output file {} failed!",
+                    dot_output_file.unwrap()
+                );
+                eprintln!("Error: {:?}", save_result.err().unwrap());
+            }
         }
         return Err(e);
     }


### PR DESCRIPTION
This PR adds a `--dot <file>` command line option that will render the traversed page graph as a graphiz Dot file.

Any pages that returned a 404 or other HTTP error code will be colored red.
Pages that were fetched but not parsed/scraped will be colored orange.
Pages that were fetched, scraped, and have all good links will be colored green.
Pages that were not fetched will be colored black.