### PR TITLE
Improve test suite

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -92,6 +92,11 @@ pub async fn visit_page(
 
             // Record the HTTP status code
             page.status_code = Some(response.status());
+            if !response.status().is_success() {
+                println!("Found bad link! {}", url);
+                page.good = Some(false);
+                return false;
+            }
 
             // Attempt to get the Content-Type of the page
             let (parse_html, content_type) = check_content_type(&response);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,7 +89,6 @@ async fn test_two_pages() {
 }
 
 
-
 #[tokio::test]
 async fn test_missing_page() {
     let mut server = Server::new();
@@ -117,7 +116,7 @@ async fn test_missing_page() {
     // Make sure the HTTP request was made to the missing page
     missing_page_mock.assert();
 
-    // Make sure that visit _website() returned true
+    // Make sure that visit _website() returned false
     assert!(!success);
 
     let graph = &spider_crab.graph;
@@ -131,6 +130,134 @@ async fn test_missing_page() {
 
     // Make sure that the page map contains the mock page
     assert!(map.contains_key(&parsed_url));
+
+    // Make sure there are two pages in the page map
+    assert_eq!(map.len(), 2);
+}
+
+
+#[tokio::test]
+async fn test_missing_href() {
+    let mut server = Server::new();
+
+    let url = server.url();
+    let parsed_url = Url::parse(url.as_str()).unwrap();
+
+    let mock = server.mock("GET", "/")
+      .with_status(201)
+      .with_header("content-type", "text/html")
+      .with_body("<!DOCTYPE html><html><body><a>This link doesn't have an href attribute!</a></body></html>")
+      .create();
+
+    let mut spider_crab = SpiderCrab::new(&[url.as_str()]);
+
+    let success = spider_crab.visit_website(url.as_str()).await;
+
+    // Make sure the HTTP request was made to the first page
+    mock.assert();
+
+    // Make sure that visit _website() returned false
+    assert!(!success);
+
+    let graph = &spider_crab.graph;
+    // Make sure that the page graph contains one page
+    assert_eq!(graph.node_count(), 1);
+
+    // Make sure there are no links in the page graph
+    assert_eq!(graph.edge_count(), 0);
+
+    let map = &spider_crab.map;
+
+    // Make sure that the page map contains the mock page
+    assert!(map.contains_key(&parsed_url));
+
+    // Make sure there is only one page in the page map
+    assert_eq!(map.len(), 1);
+}
+
+
+#[tokio::test]
+async fn test_empty_href() {
+    let mut server = Server::new();
+
+    let url = server.url();
+    let parsed_url = Url::parse(url.as_str()).unwrap();
+
+    let mock = server.mock("GET", "/")
+      .with_status(201)
+      .with_header("content-type", "text/html")
+      .with_body("<!DOCTYPE html><html><body><a href=\"\">This link's href attribute is empty!</a></body></html>")
+      .create();
+
+    let mut spider_crab = SpiderCrab::new(&[url.as_str()]);
+
+    let success = spider_crab.visit_website(url.as_str()).await;
+
+    // Make sure the HTTP request was made to the first page
+    mock.assert();
+
+    // Make sure that visit _website() returned false
+    assert!(!success);
+
+    let graph = &spider_crab.graph;
+    // Make sure that the page graph contains one page
+    assert_eq!(graph.node_count(), 1);
+
+    // Make sure there are no links in the page graph
+    assert_eq!(graph.edge_count(), 0);
+
+    let map = &spider_crab.map;
+
+    // Make sure that the page map contains the mock page
+    assert!(map.contains_key(&parsed_url));
+
+    // Make sure there is only one page in the page map
+    assert_eq!(map.len(), 1);
+}
+
+
+#[tokio::test]
+async fn test_empty_href_in_second_page() {
+    let mut server = Server::new();
+
+    let url = server.url();
+    let parsed_url = Url::parse(url.as_str()).unwrap();
+
+    let mock = server.mock("GET", "/")
+      .with_status(201)
+      .with_header("content-type", "text/html")
+      .with_body("<!DOCTYPE html><html><body><a href=\"pageB.html\">This is a link to page B.</a></body></html>")
+      .create();
+
+    let mock_page_b = server.mock("GET", "/pageB.html")
+      .with_status(201)
+      .with_header("content-type", "text/html")
+      .with_body("<!DOCTYPE html><html><body><a href=\"\">This link has an empty href attribute!</a></body></html>")
+      .create();
+
+    let mut spider_crab = SpiderCrab::new(&[url.as_str()]);
+
+    let success = spider_crab.visit_website(url.as_str()).await;
+
+    // Make sure the HTTP request was made to the first page
+    mock.assert();
+    mock_page_b.assert();
+
+    // Make sure that visit _website() returned false
+    assert!(!success);
+
+    let graph = &spider_crab.graph;
+    // Make sure that the page graph contains two pages
+    assert_eq!(graph.node_count(), 2);
+
+    // Make sure there are is only one link in the graph
+    assert_eq!(graph.edge_count(), 1);
+
+    let map = &spider_crab.map;
+
+    // Make sure that the page map contains the mock page
+    assert!(map.contains_key(&parsed_url));
+    assert!(map.contains_key(&parsed_url.join("pageB.html").unwrap()));
 
     // Make sure there are two pages in the page map
     assert_eq!(map.len(), 2);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -88,7 +88,6 @@ async fn test_two_pages() {
     assert_eq!(map.len(), 2);
 }
 
-
 #[tokio::test]
 async fn test_missing_page() {
     let mut server = Server::new();
@@ -102,9 +101,7 @@ async fn test_missing_page() {
       .with_body("<!DOCTYPE html><html><body><a href=\"page2.html\" >This points to a missing page!</a></body></html>")
       .create();
 
-    let missing_page_mock = server.mock("GET", "/page2.html")
-      .with_status(404)
-      .create();
+    let missing_page_mock = server.mock("GET", "/page2.html").with_status(404).create();
 
     let mut spider_crab = SpiderCrab::new(&[url.as_str()]);
 
@@ -134,7 +131,6 @@ async fn test_missing_page() {
     // Make sure there are two pages in the page map
     assert_eq!(map.len(), 2);
 }
-
 
 #[tokio::test]
 async fn test_missing_href() {
@@ -175,7 +171,6 @@ async fn test_missing_href() {
     assert_eq!(map.len(), 1);
 }
 
-
 #[tokio::test]
 async fn test_empty_href() {
     let mut server = Server::new();
@@ -214,7 +209,6 @@ async fn test_empty_href() {
     // Make sure there is only one page in the page map
     assert_eq!(map.len(), 1);
 }
-
 
 #[tokio::test]
 async fn test_empty_href_in_second_page() {


### PR DESCRIPTION
PR to resolve issue #4 
Adds tests for error cases.
Found a bug with HTTP status codes. I had assumed that the `response_result` from tokio would be an `Err` if the HTTP status code was not a `2XX` value, but turns out this is not the case.