### PR TITLE
Add logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ futures = "0.3.29"
 petgraph = "0.6.4"
 reqwest = "0.11.22"
 scraper = "0.18.1"
+stderrlog = "0.5.4"
+log = "0.4.20"
 tokio = { version = "1.34.0", features = ["macros"] }
 url = "2.4.1"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ pub struct SpiderError {
 #[derive(Debug)]
 pub enum SpiderErrorType {
     InvalidURL,
-    MissingPage,
+    HTTPError,
     UnableToRetrieve,
     MissingHref,
     EmptyHref,
@@ -33,12 +33,13 @@ impl std::fmt::Display for SpiderError {
 impl SpiderError {
     fn get_message(&self) -> String {
         match &self.error_type {
-            SpiderErrorType::MissingPage => format!(
-                "Page at {:?} does not exist!",
-                self.target_page.as_ref().unwrap()
-            ),
             SpiderErrorType::UnableToRetrieve => format!(
                 "Failed to retrieve content for page {:?}!",
+                self.target_page.as_ref().unwrap()
+            ),
+            SpiderErrorType::HTTPError => format!(
+                "HTTP GET request received status code {:?} for page {:?}!",
+                self.http_error_code.as_ref().unwrap(),
                 self.target_page.as_ref().unwrap()
             ),
             SpiderErrorType::InvalidURL => format!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,8 @@ pub struct SpiderError {
 #[derive(Debug)]
 pub enum SpiderErrorType {
     InvalidURL,
-    BrokenLink,
+    MissingPage,
+    UnableToRetrieve,
     MissingHref,
     EmptyHref,
     MissingTitle,
@@ -32,10 +33,12 @@ impl std::fmt::Display for SpiderError {
 impl SpiderError {
     fn get_message(&self) -> String {
         match &self.error_type {
-            SpiderErrorType::BrokenLink => format!(
-                "Page at {:?} contains a link pointing to {:?}, but {:?} is a bad link!",
-                self.source_page.as_ref().unwrap(),
-                self.target_page.as_ref().unwrap(),
+            SpiderErrorType::MissingPage => format!(
+                "Page at {:?} does not exist!",
+                self.target_page.as_ref().unwrap()
+            ),
+            SpiderErrorType::UnableToRetrieve => format!(
+                "Failed to retrieve content for page {:?}!",
                 self.target_page.as_ref().unwrap()
             ),
             SpiderErrorType::InvalidURL => format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use error::SpiderError;
-use log::{error, info, warn};
+
 use petgraph::graph::{DiGraph, NodeIndex};
 use reqwest::StatusCode;
 use scraper::{selector::CssLocalName, Selector};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use error::SpiderError;
+use log::{error, info, warn};
 use petgraph::graph::{DiGraph, NodeIndex};
 use reqwest::StatusCode;
 use scraper::{selector::CssLocalName, Selector};
@@ -69,10 +70,6 @@ pub struct SpiderOptions {
     pub link_selector: Box<Selector>,
     /// Scraper CSS Selector for title elements
     pub title_selector: Box<Selector>,
-    /// Flag to enable quiet mode. True if quiet mode enabled.
-    pub quiet: bool,
-    /// Flag to enable verbose mode. True if verbose mode enabled.
-    pub verbose: bool,
     /// Name of the CSS class that marks elements to not check URLs for
     pub skip_class: CssLocalName,
     /// Vector of hosts (domain names and IP addresses) that Spider Crab will traverse
@@ -104,11 +101,6 @@ impl Default for SpiderOptions {
             max_depth: -1,
             link_selector: Box::new(Selector::parse("a").expect("Invalid title selector!")),
             title_selector: Box::new(Selector::parse("title").expect("Invalid title selector!")),
-            quiet: false,
-            #[cfg(test)]
-            verbose: true,
-            #[cfg(not(test))]
-            verbose: false,
             skip_class: CssLocalName::from("scrab-skip"),
             hosts: vec![],
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-use log::{error, info, warn};
+use log::{error, info};
 use std::fs::File;
 use std::io::Write;
-use stderrlog;
 
 use clap::{Arg, ArgAction, Command};
 use spider_crab::error::SpiderError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,14 +38,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .arg(
             Arg::new("quiet")
                 .short('q')
-                .action(ArgAction::Append)
-                .help("Increase message verbosity"),
+                .action(ArgAction::SetTrue)
+                .help("Silence logging output."),
         )
         .arg(
             Arg::new("verbosity")
                 .short('v')
-                .long("verbose")
-                .action(ArgAction::SetTrue)
+                .action(ArgAction::Count)
                 .help("Print more log messages."),
         )
         .arg(
@@ -64,17 +63,14 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     let depth: i32 = *matches.get_one::<i32>("depth").expect("Invalid depth!");
 
-    let verbose: usize = matches
-        .get_occurrences::<usize>("verbosity")
-        .unwrap()
-        .count();
+    let verbose = matches.get_count("verbosity");
 
     let dot_output_file = matches.get_one::<String>("dot");
 
     stderrlog::new()
         .module(module_path!())
         .quiet(matches.get_flag("quiet"))
-        .verbosity(verbose)
+        .verbosity(verbose as usize)
         .init()
         .unwrap();
 


### PR DESCRIPTION
This pull request does the following:
- Adds the `log` and `stderrlog` crates as dependencies
- Fixes a bug where errors were being printed instead of added to the page's error list. These error cases now added to the page's error list.
- Allows finer grained control over log level via `-v` flag

Resolves #11 